### PR TITLE
Add ANALOG_WRITE to FastIO headers

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
@@ -94,6 +94,8 @@
   #define extDigitalRead(IO)    digitalRead(IO)
 #endif
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 #define READ(IO)              _READ(IO)
 #define WRITE(IO,V)           _WRITE(IO,V)
 #define TOGGLE(IO)            _TOGGLE(IO)

--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -187,6 +187,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 /**
  * Ports and functions
  * Added as necessary or if I feel like it- not a comprehensive list!

--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -57,6 +57,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 //
 // Ports and functions
 //

--- a/Marlin/src/HAL/HAL_LINUX/fastio.h
+++ b/Marlin/src/HAL/HAL_LINUX/fastio.h
@@ -125,3 +125,5 @@
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
+
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -125,3 +125,5 @@
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
+
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -83,3 +83,5 @@ void FastIO_init(); // Must be called before using fast io macros
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
+
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)

--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -54,3 +54,5 @@
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
+
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -58,6 +58,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 //
 // Pins Definitions
 //

--- a/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
@@ -57,6 +57,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 //
 // Pins Definitions
 //

--- a/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
@@ -89,6 +89,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 /**
  * Ports, functions, and pins
  */

--- a/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
@@ -88,6 +88,8 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+
 /**
  * Ports, functions, and pins
  */

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -976,7 +976,7 @@ void setup() {
     #endif
     #if ENABLED(SPINDLE_LASER_PWM) && defined(SPINDLE_LASER_PWM_PIN) && SPINDLE_LASER_PWM_PIN >= 0
       SET_OUTPUT(SPINDLE_LASER_PWM_PIN);
-      analogWrite(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);  // set to lowest speed
+      ANALOG_WRITE(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);  // set to lowest speed
     #endif
   #endif
 

--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -70,7 +70,7 @@ void update_case_light() {
   #else // !CASE_LIGHT_USE_NEOPIXEL
 
     if (USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN))
-      analogWrite(CASE_LIGHT_PIN, n10ct);
+      ANALOG_WRITE(CASE_LIGHT_PIN, n10ct);
     else {
       const bool s = case_light_on ? !INVERT_CASE_LIGHT : INVERT_CASE_LIGHT;
       WRITE(CASE_LIGHT_PIN, s ? HIGH : LOW);

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -81,7 +81,7 @@ void controllerfan_update() {
 
     // allows digital or PWM fan output to be used (see M42 handling)
     WRITE(CONTROLLER_FAN_PIN, speed);
-    analogWrite(CONTROLLER_FAN_PIN, speed);
+    ANALOG_WRITE(CONTROLLER_FAN_PIN, speed);
   }
 }
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -115,13 +115,13 @@ void LEDLights::set_color(const LEDColor &incol
     WRITE(RGB_LED_R_PIN, incol.r ? HIGH : LOW);
     WRITE(RGB_LED_G_PIN, incol.g ? HIGH : LOW);
     WRITE(RGB_LED_B_PIN, incol.b ? HIGH : LOW);
-    analogWrite(RGB_LED_R_PIN, incol.r);
-    analogWrite(RGB_LED_G_PIN, incol.g);
-    analogWrite(RGB_LED_B_PIN, incol.b);
+    ANALOG_WRITE(RGB_LED_R_PIN, incol.r);
+    ANALOG_WRITE(RGB_LED_G_PIN, incol.g);
+    ANALOG_WRITE(RGB_LED_B_PIN, incol.b);
 
     #if ENABLED(RGBW_LED)
       WRITE(RGB_LED_W_PIN, incol.w ? HIGH : LOW);
-      analogWrite(RGB_LED_W_PIN, incol.w);
+      ANALOG_WRITE(RGB_LED_W_PIN, incol.w);
     #endif
 
   #endif

--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -74,7 +74,7 @@ inline void delay_for_power_down() { safe_delay(SPINDLE_LASER_POWERDOWN_DELAY); 
 
 inline void set_spindle_laser_ocr(const uint8_t ocr) {
   WRITE(SPINDLE_LASER_ENABLE_PIN, SPINDLE_LASER_ENABLE_INVERT); // turn spindle on (active low)
-  analogWrite(SPINDLE_LASER_PWM_PIN, (SPINDLE_LASER_PWM_INVERT) ? 255 - ocr : ocr);
+  ANALOG_WRITE(SPINDLE_LASER_PWM_PIN, (SPINDLE_LASER_PWM_INVERT) ? 255 - ocr : ocr);
 }
 
 #if ENABLED(SPINDLE_LASER_PWM)
@@ -82,7 +82,7 @@ inline void set_spindle_laser_ocr(const uint8_t ocr) {
   void update_spindle_laser_power() {
     if (spindle_laser_power == 0) {
       WRITE(SPINDLE_LASER_ENABLE_PIN, !SPINDLE_LASER_ENABLE_INVERT);                      // turn spindle off (active low)
-      analogWrite(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);             // only write low byte
+      ANALOG_WRITE(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);             // only write low byte
       delay_for_power_down();
     }
     else {                                                                                // Convert RPM to PWM duty cycle

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -51,7 +51,7 @@ void GcodeSuite::M42() {
 
   pinMode(pin, OUTPUT);
   extDigitalWrite(pin, pin_status);
-  analogWrite(pin, pin_status);
+  ANALOG_WRITE(pin, pin_status);
 
   #if FAN_COUNT > 0
     switch (pin) {

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -883,7 +883,7 @@ void Endstops::update() {
         ES_REPORT_CHANGE(Z3_MAX);
       #endif
       SERIAL_ECHOLNPGM("\n");
-      analogWrite(LED_PIN, local_LED_status);
+      ANALOG_WRITE(LED_PIN, local_LED_status);
       local_LED_status ^= 255;
       old_live_state_local = live_state_local;
     }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1287,13 +1287,13 @@ void Planner::check_axes_activity() {
 
     #else
       #if HAS_FAN0
-        analogWrite(FAN_PIN, CALC_FAN_SPEED(0));
+        ANALOG_WRITE(FAN_PIN, CALC_FAN_SPEED(0));
       #endif
       #if HAS_FAN1
-        analogWrite(FAN1_PIN, CALC_FAN_SPEED(1));
+        ANALOG_WRITE(FAN1_PIN, CALC_FAN_SPEED(1));
       #endif
       #if HAS_FAN2
-        analogWrite(FAN2_PIN, CALC_FAN_SPEED(2));
+        ANALOG_WRITE(FAN2_PIN, CALC_FAN_SPEED(2));
       #endif
     #endif
 
@@ -1305,10 +1305,10 @@ void Planner::check_axes_activity() {
 
   #if ENABLED(BARICUDA)
     #if HAS_HEATER_1
-      analogWrite(HEATER_1_PIN, tail_valve_pressure);
+      ANALOG_WRITE(HEATER_1_PIN, tail_valve_pressure);
     #endif
     #if HAS_HEATER_2
-      analogWrite(HEATER_2_PIN, tail_e_to_p_pressure);
+      ANALOG_WRITE(HEATER_2_PIN, tail_e_to_p_pressure);
     #endif
   #endif
 }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2510,7 +2510,7 @@ void Stepper::report_positions() {
         if (WITHIN(driver, 0, COUNT(motor_current_setting) - 1))
           motor_current_setting[driver] = current; // update motor_current_setting
 
-        #define _WRITE_CURRENT_PWM(P) analogWrite(MOTOR_CURRENT_PWM_## P ##_PIN, 255L * current / (MOTOR_CURRENT_PWM_RANGE))
+        #define _WRITE_CURRENT_PWM(P) ANALOG_WRITE(MOTOR_CURRENT_PWM_## P ##_PIN, 255L * current / (MOTOR_CURRENT_PWM_RANGE))
         switch (driver) {
           case 0:
             #if PIN_EXISTS(MOTOR_CURRENT_PWM_X)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -635,7 +635,7 @@ int Temperature::getHeaterPower(const int heater) {
 
     #define _UPDATE_AUTO_FAN(P,D,A) do{           \
       if (USEABLE_HARDWARE_PWM(P##_AUTO_FAN_PIN)) \
-        analogWrite(P##_AUTO_FAN_PIN, A);         \
+        ANALOG_WRITE(P##_AUTO_FAN_PIN, A);        \
       else                                        \
         WRITE(P##_AUTO_FAN_PIN, D);               \
     }while(0)


### PR DESCRIPTION
Placeholders for analog write, so we can scale it for platforms that use a 16-bit range.