### PR TITLE
Add SET_PWM, modify ANALOG_WRITE on STM32Fx

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
@@ -104,6 +104,8 @@
 #define SET_INPUT_PULLUP(IO)  do{ _SET_INPUT(IO); _WRITE(IO, HIGH); }while(0)
 #define SET_OUTPUT(IO)        _SET_OUTPUT(IO)
 
+#define SET_PWM(IO)           SET_OUTPUT(IO)
+
 #define GET_INPUT(IO)         _GET_INPUT(IO)
 #define GET_OUTPUT(IO)        _GET_OUTPUT(IO)
 #define GET_TIMER(IO)         _GET_TIMER(IO)

--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -173,6 +173,9 @@
 // Set pin as output (wrapper) -  reads the pin and sets the output to that value
 #define SET_OUTPUT(IO) _SET_OUTPUT(IO)
 
+// Set pin as PWM
+#define SET_PWM(IO) SET_OUTPUT(IO)
+
 // Check if pin is an input
 #define GET_INPUT(IO) !(digitalPinToPort(IO)->PIO_OSR & digitalPinToBitMask(IO))
 // Check if pin is an output

--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -51,6 +51,10 @@
 // Set pin as output wrapper
 #define SET_OUTPUT(IO)        do{ _SET_OUTPUT(IO); WRITE(IO, LOW); }while(0)
 
+// Set pin as PWM
+#define SET_PWM(IO)           SET_OUTPUT(IO)
+
+// Set pin as output and init
 #define OUT_WRITE(IO,V)       do{ _SET_OUTPUT(IO); WRITE(IO,V); }while(0)
 
 // digitalRead/Write wrappers

--- a/Marlin/src/HAL/HAL_LINUX/fastio.h
+++ b/Marlin/src/HAL/HAL_LINUX/fastio.h
@@ -110,6 +110,8 @@
 #define SET_INPUT_PULLDOWN(IO)  do{ _SET_INPUT(IO); _PULLDOWN(IO, HIGH); }while(0)
 /// set pin as output wrapper  -  reads the pin and sets the output to that value
 #define SET_OUTPUT(IO)          do{ _WRITE(IO, _READ(IO)); _SET_OUTPUT(IO); }while(0)
+// set pin as PWM
+#define SET_PWM(IO)       SET_OUTPUT(IO)
 
 /// check if pin is an input wrapper
 #define GET_INPUT(IO)     _GET_INPUT(IO)

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -110,6 +110,8 @@
 #define SET_INPUT_PULLDOWN(IO)  do{ _SET_INPUT(IO); _PULLDOWN(IO, HIGH); }while(0)
 /// set pin as output wrapper  -  reads the pin and sets the output to that value
 #define SET_OUTPUT(IO)          do{ _WRITE(IO, _READ(IO)); _SET_OUTPUT(IO); }while(0)
+// set pin as PWM
+#define SET_PWM(IO)       SET_OUTPUT(IO)
 
 /// check if pin is an input wrapper
 #define GET_INPUT(IO)     _GET_INPUT(IO)

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -72,6 +72,7 @@ void FastIO_init(); // Must be called before using fast io macros
 #define SET_INPUT_PULLUP(IO)    _SET_MODE(IO, INPUT_PULLUP)                       /*!< Input with Pull-up activation         */
 #define SET_INPUT_PULLDOWN(IO)  _SET_MODE(IO, INPUT_PULLDOWN)                     /*!< Input with Pull-down activation       */
 #define SET_OUTPUT(IO)          OUT_WRITE(IO, LOW)
+#define SET_PWM(IO)             _SET_MODE(IO, PWM)
 
 #define GET_INPUT(IO)
 #define GET_OUTPUT(IO)

--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -43,6 +43,7 @@
 #define SET_INPUT(IO)         _SET_MODE(IO, GPIO_INPUT_FLOATING)
 #define SET_INPUT_PULLUP(IO)  _SET_MODE(IO, GPIO_INPUT_PU)
 #define SET_OUTPUT(IO)        OUT_WRITE(IO,LOW)
+#define SET_PWM(IO)           _SET_MODE(IO, PWM)
 
 #define GET_INPUT(IO)         (_GET_MODE(IO) == GPIO_INPUT_FLOATING || _GET_MODE(IO) == GPIO_INPUT_ANALOG || _GET_MODE(IO) == GPIO_INPUT_PU || _GET_MODE(IO) == GPIO_INPUT_PD)
 #define GET_OUTPUT(IO)        (_GET_MODE(IO) == GPIO_OUTPUT_PP)
@@ -55,4 +56,4 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
-#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,(V)*65535/255)

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -44,6 +44,7 @@
 #define SET_INPUT_PULLUP(IO)    _SET_MODE(IO, INPUT_PULLUP)                       /*!< Input with Pull-up activation         */
 #define SET_INPUT_PULLDOWN(IO)  _SET_MODE(IO, INPUT_PULLDOWN)                     /*!< Input with Pull-down activation       */
 #define SET_OUTPUT(IO)          OUT_WRITE(IO, LOW)
+#define SET_PWM(IO)             _SET_MODE(IO, PWM)
 
 #define TOGGLE(IO)              OUT_WRITE(IO, !READ(IO))
 
@@ -58,7 +59,7 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
-#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,(V)*65535/255)
 
 //
 // Pins Definitions

--- a/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
@@ -43,6 +43,7 @@
 #define SET_INPUT_PULLUP(IO)    _SET_MODE(IO, INPUT_PULLUP)                       /*!< Input with Pull-up activation         */
 #define SET_INPUT_PULLDOWN(IO)  _SET_MODE(IO, INPUT_PULLDOWN)                     /*!< Input with Pull-down activation       */
 #define SET_OUTPUT(IO)          OUT_WRITE(IO, LOW)
+#define SET_PWM(IO)             _SET_MODE(IO, PWM)
 
 #define TOGGLE(IO)              OUT_WRITE(IO, !READ(IO))
 
@@ -57,7 +58,7 @@
 #define extDigitalRead(IO)    digitalRead(IO)
 #define extDigitalWrite(IO,V) digitalWrite(IO,V)
 
-#define ANALOG_WRITE(IO,V)    analogWrite(IO,V)
+#define ANALOG_WRITE(IO,V)    analogWrite(IO,(V)*65535/255)
 
 //
 // Pins Definitions

--- a/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
@@ -80,6 +80,8 @@
 #define SET_INPUT_PULLUP(IO)  _SET_INPUT_PULLUP(IO)
 #define SET_OUTPUT(IO)        _SET_OUTPUT(IO)
 
+#define SET_PWM(IO)           SET_OUTPUT(IO)
+
 #define GET_INPUT(IO)         _GET_INPUT(IO)
 #define GET_OUTPUT(IO)        _GET_OUTPUT(IO)
 

--- a/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
@@ -79,6 +79,8 @@
 #define SET_INPUT_PULLUP(IO)  _SET_INPUT_PULLUP(IO)
 #define SET_OUTPUT(IO)        _SET_OUTPUT(IO)
 
+#define SET_PWM(IO)           SET_OUTPUT(IO)
+
 #define GET_INPUT(IO)         _GET_INPUT(IO)
 #define GET_OUTPUT(IO)        _GET_OUTPUT(IO)
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -975,7 +975,7 @@ void setup() {
       OUT_WRITE(SPINDLE_DIR_PIN, SPINDLE_INVERT_DIR ? 255 : 0);  // init rotation to clockwise (M3)
     #endif
     #if ENABLED(SPINDLE_LASER_PWM) && defined(SPINDLE_LASER_PWM_PIN) && SPINDLE_LASER_PWM_PIN >= 0
-      SET_OUTPUT(SPINDLE_LASER_PWM_PIN);
+      SET_PWM(SPINDLE_LASER_PWM_PIN);
       ANALOG_WRITE(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);  // set to lowest speed
     #endif
   #endif
@@ -1022,7 +1022,11 @@ void setup() {
 
   #if HAS_CASE_LIGHT
     #if DISABLED(CASE_LIGHT_USE_NEOPIXEL)
-      SET_OUTPUT(CASE_LIGHT_PIN);
+      #if USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)
+        SET_PWM(CASE_LIGHT_PIN);
+      #else
+        SET_OUTPUT(CASE_LIGHT_PIN);
+      #endif
     #endif
     update_case_light();
   #endif

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -61,11 +61,27 @@ LEDLights leds;
 
 void LEDLights::setup() {
   #if ENABLED(RGB_LED) || ENABLED(RGBW_LED)
-    SET_OUTPUT(RGB_LED_R_PIN);
-    SET_OUTPUT(RGB_LED_G_PIN);
-    SET_OUTPUT(RGB_LED_B_PIN);
+    #if USEABLE_HARDWARE_PWM(RGB_LED_R_PIN)
+      SET_PWM(RGB_LED_R_PIN);
+    #else
+      SET_OUTPUT(RGB_LED_R_PIN);
+    #endif
+    #if USEABLE_HARDWARE_PWM(RGB_LED_G_PIN)
+      SET_PWM(RGB_LED_G_PIN);
+    #else
+      SET_OUTPUT(RGB_LED_G_PIN);
+    #endif
+    #if USEABLE_HARDWARE_PWM(RGB_LED_B_PIN)
+      SET_PWM(RGB_LED_B_PIN);
+    #else
+      SET_OUTPUT(RGB_LED_B_PIN);
+    #endif
     #if ENABLED(RGBW_LED)
-      SET_OUTPUT(RGB_LED_W_PIN);
+      #if USEABLE_HARDWARE_PWM(RGB_LED_W_PIN)
+        SET_PWM(RGB_LED_W_PIN);
+      #else
+        SET_OUTPUT(RGB_LED_W_PIN);
+      #endif
     #endif
   #endif
   #if ENABLED(NEOPIXEL_LED)
@@ -112,16 +128,12 @@ void LEDLights::set_color(const LEDColor &incol
 
     // This variant uses 3-4 separate pins for the RGB(W) components.
     // If the pins can do PWM then their intensity will be set.
-    WRITE(RGB_LED_R_PIN, incol.r ? HIGH : LOW);
-    WRITE(RGB_LED_G_PIN, incol.g ? HIGH : LOW);
-    WRITE(RGB_LED_B_PIN, incol.b ? HIGH : LOW);
-    ANALOG_WRITE(RGB_LED_R_PIN, incol.r);
-    ANALOG_WRITE(RGB_LED_G_PIN, incol.g);
-    ANALOG_WRITE(RGB_LED_B_PIN, incol.b);
-
+    #define UPDATE_RGBW(C,c) do{ if (USEABLE_HARDWARE_PWM(RGB_LED_##C##_PIN)) ANALOG_WRITE(RGB_LED_##C##_PIN, incol.r); else WRITE(RGB_LED_##C##_PIN, incol.c ? HIGH : LOW); }while(0)
+    UPDATE_RGBW(R,r);
+    UPDATE_RGBW(G,g);
+    UPDATE_RGBW(B,b);
     #if ENABLED(RGBW_LED)
-      WRITE(RGB_LED_W_PIN, incol.w ? HIGH : LOW);
-      ANALOG_WRITE(RGB_LED_W_PIN, incol.w);
+      UPDATE_RGBW(W,w);
     #endif
 
   #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1698,13 +1698,13 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if HAS_AUTO_FAN && EXTRUDER_AUTO_FAN_SPEED != 255
   #define AF_ERR_SUFF "_AUTO_FAN_PIN is not a PWM pin. Set EXTRUDER_AUTO_FAN_SPEED to 255."
   #if HAS_AUTO_FAN_0
-    static_assert(GET_TIMER(E0_AUTO_FAN_PIN), "E0" AF_ERR_SUFF);
+    static_assert(USEABLE_HARDWARE_PWM(E0_AUTO_FAN_PIN), "E0" AF_ERR_SUFF);
   #elif HAS_AUTO_FAN_1
-    static_assert(GET_TIMER(E1_AUTO_FAN_PIN), "E1" AF_ERR_SUFF);
+    static_assert(USEABLE_HARDWARE_PWM(E1_AUTO_FAN_PIN), "E1" AF_ERR_SUFF);
   #elif HAS_AUTO_FAN_2
-    static_assert(GET_TIMER(E2_AUTO_FAN_PIN), "E2" AF_ERR_SUFF);
+    static_assert(USEABLE_HARDWARE_PWM(E2_AUTO_FAN_PIN), "E2" AF_ERR_SUFF);
   #elif HAS_AUTO_FAN_3
-    static_assert(GET_TIMER(E3_AUTO_FAN_PIN), "E3" AF_ERR_SUFF);
+    static_assert(USEABLE_HARDWARE_PWM(E3_AUTO_FAN_PIN), "E3" AF_ERR_SUFF);
   #endif
 #endif
 
@@ -2014,7 +2014,7 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #endif
 
 #if ENABLED(FAST_PWM_FAN) && !(defined(ARDUINO) && !defined(ARDUINO_ARCH_SAM))
-  #error "FAST_PWM_FAN only supported by 8 bit CPUs."
+  #error "FAST_PWM_FAN is only supported for ARDUINO and ARDUINO_ARCH_SAM."
 #endif
 
 #if ENABLED(Z_STEPPER_AUTO_ALIGN)

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2560,25 +2560,25 @@ void Stepper::report_positions() {
       #elif HAS_MOTOR_CURRENT_PWM
 
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_X)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_X_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_X_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_Y)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_Y_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_Y_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_XY_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_XY_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_Z_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_Z_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_E_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_E_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_E0)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_E0_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_E0_PIN);
         #endif
         #if PIN_EXISTS(MOTOR_CURRENT_PWM_E1)
-          SET_OUTPUT(MOTOR_CURRENT_PWM_E1_PIN);
+          SET_PWM(MOTOR_CURRENT_PWM_E1_PIN);
         #endif
 
         refresh_motor_power();


### PR DESCRIPTION
- `SET_PWM` is an alias to `SET_OUTPUT` on all platforms except STM32.
- `ANALOG_WRITE` scales the value on STM32.

It'd be better to check for the presence of libmaple and check its version.