### PR TITLE
Patch SET_PWM for STM32F1/4 libmaple

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -42,14 +42,14 @@
 
 #define SET_INPUT(IO)         _SET_MODE(IO, GPIO_INPUT_FLOATING)
 #define SET_INPUT_PULLUP(IO)  _SET_MODE(IO, GPIO_INPUT_PU)
-#define SET_OUTPUT(IO)        OUT_WRITE(IO,LOW)
-#define SET_PWM(IO)           _SET_MODE(IO, PWM)
+#define SET_OUTPUT(IO)        OUT_WRITE(IO, LOW)
+#define SET_PWM(IO)           pinMode(IO, PWM)    // do{ gpio_set_mode(PIN_MAP[pin].gpio_device, PIN_MAP[pin].gpio_bit, GPIO_AF_OUTPUT_PP); timer_set_mode(PIN_MAP[pin].timer_device, PIN_MAP[pin].timer_channel, TIMER_PWM); }while(0)
 
 #define GET_INPUT(IO)         (_GET_MODE(IO) == GPIO_INPUT_FLOATING || _GET_MODE(IO) == GPIO_INPUT_ANALOG || _GET_MODE(IO) == GPIO_INPUT_PU || _GET_MODE(IO) == GPIO_INPUT_PD)
 #define GET_OUTPUT(IO)        (_GET_MODE(IO) == GPIO_OUTPUT_PP)
 #define GET_TIMER(IO)         (PIN_MAP[IO].timer_device != NULL)
 
-#define PWM_PIN(p) true
+#define PWM_PIN(p)
 #define USEABLE_HARDWARE_PWM(p) PWM_PIN(p)
 
 // digitalRead/Write wrappers

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -44,7 +44,7 @@
 #define SET_INPUT_PULLUP(IO)    _SET_MODE(IO, INPUT_PULLUP)                       /*!< Input with Pull-up activation         */
 #define SET_INPUT_PULLDOWN(IO)  _SET_MODE(IO, INPUT_PULLDOWN)                     /*!< Input with Pull-down activation       */
 #define SET_OUTPUT(IO)          OUT_WRITE(IO, LOW)
-#define SET_PWM(IO)             _SET_MODE(IO, PWM)
+#define SET_PWM(IO)             pinMode(IO, PWM)
 
 #define TOGGLE(IO)              OUT_WRITE(IO, !READ(IO))
 


### PR DESCRIPTION
The `PWM` define is used by `pinMode`, which is preferable to use in fastIO instead of inlining the equivalent code, considering that we don't change pin modes all the time.